### PR TITLE
Attempt to read view paths from `ApplicationController`

### DIFF
--- a/app/controllers/action_view/storybook/stories_controller.rb
+++ b/app/controllers/action_view/storybook/stories_controller.rb
@@ -6,7 +6,6 @@ module ActionView
   module Storybook
     class StoriesController < Rails::ApplicationController
       prepend_view_path File.expand_path("../../../views", __dir__)
-      prepend_view_path Rails.root.join("app/views") if defined?(Rails.root)
       prepend_view_path Rails.application.config.storybook_rails.stories_path
 
       before_action :find_stories, :find_story, only: :show

--- a/lib/action_view/storybook/engine.rb
+++ b/lib/action_view/storybook/engine.rb
@@ -8,6 +8,17 @@ module ActionView
     class Engine < Rails::Engine
       config.storybook_rails = ActiveSupport::OrderedOptions.new
 
+      config.to_prepare do
+        view_path =
+          if defined?(ApplicationController)
+            ::ApplicationController.view_paths
+          else
+            Rails.root.join("app/views")
+          end
+
+        ActionView::Storybook::StoriesController.prepend_view_path view_path
+      end
+
       initializer "storybook_rails.set_configs" do |app|
         options = app.config.storybook_rails
 


### PR DESCRIPTION
Prepend views from a host application's `ApplicationController`, if available. If not, fallback to the `Rails.root.join("app/views")` path from before this change.